### PR TITLE
SSD-95 - Add a cli task to query the dependabot config API and store data on

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,8 @@ test:
 audit:
 	docker-compose run dashboard flask audit
 
+dependabot_status:
+	docker-compose run dashboard flask dependabot-status alphagov
+
 gulp:
 	docker-compose run dashboard sh -c 'cd build && npm install && npm rebuild node-sass && gulp'

--- a/app.py
+++ b/app.py
@@ -3,11 +3,13 @@ import json
 import click
 from flask import Flask
 from flask import render_template
+from addict import Dict
 
 import pgraph
 import repository_summarizer
 import vulnerability_summarizer
 import stats
+import dependabot_api
 
 
 app = Flask(__name__, static_url_path="/assets")
@@ -61,6 +63,26 @@ def cronable_audit():
         updated = True
     except Exception as err:
         updated = False
+    return updated
+
+
+@app.cli.command("dependabot-status")
+@click.argument("org")
+def dependabot_status(org):
+    try:
+        updated = False
+        data = dependabot_api.get_repos_by_status(org)
+        counts = stats.count_types(data)
+        output = Dict()
+        output.counts = counts
+        output.repositories = data
+
+        with open("output/dependabot_status.json", "w") as data_file:
+            data_file.write(json.dumps(output, indent=2))
+            updated = True
+    except Exception:
+        updated = False
+
     return updated
 
 

--- a/dependabot_api.py
+++ b/dependabot_api.py
@@ -1,0 +1,38 @@
+import os
+import json
+import requests
+from addict import Dict
+
+
+ROOT_URL = "https://api.dependabot.com"
+
+
+HEADERS={
+    "Authorization": "Personal %s" % os.environ["TOKEN"]
+}
+
+
+def get(path):
+    url = ROOT_URL + path
+    response = requests.get(url, headers=HEADERS)
+    return response
+
+
+def get_parsed(path):
+    response = get(path)
+    body = Dict(json.loads(response.text))
+    return body.data
+
+
+def get_repos_by_status(org):
+    accounts = get_parsed("/accounts")
+    states = ["active","inactive"]
+    repositories = {}
+    for account in accounts:
+        if account.attributes["github-login"] == org:
+            for state in states:
+                repositories[state] = get_parsed(f"/repos?account-id={account.id}&account-type=org&installation-state={state}")
+
+    return repositories
+
+


### PR DESCRIPTION
repositories by active|inactive dependabot status.

This isn't implemented in the interface yet but stores a JSON file in /output