### PR TITLE
SSD-135: Move vulnerability analysis logic into vulnerability_summarizer.py 

### DIFF
--- a/tests/test_vulnerability_summarizer.py
+++ b/tests/test_vulnerability_summarizer.py
@@ -1,0 +1,33 @@
+import os
+import re
+import sys
+import json
+
+from addict import Dict
+
+import vulnerability_summarizer
+
+
+VERSION_TESTS = [
+    {"original": "= 1.2.3", "uniform": "1.2.3", "sortable": "0001.0002.0003"},
+    {"original": "= 1.12.3", "uniform": "1.12.3", "sortable": "0001.0012.0003"},
+    {"original": "= 1.12.20", "uniform": "1.12.20", "sortable": "0001.0012.0020"},
+]
+
+
+def test_get_uniform_version():
+    for version in VERSION_TESTS:
+        assert version["uniform"] == vulnerability_summarizer.get_uniform_version(
+            version["original"]
+        )
+
+
+def test_get_sortable_version():
+    for version in VERSION_TESTS:
+        assert version["sortable"] == vulnerability_summarizer.get_sortable_version(
+            version["original"]
+        )
+
+    assert vulnerability_summarizer.get_sortable_version(
+        "1.2.3"
+    ) < vulnerability_summarizer.get_sortable_version("1.12.3")

--- a/vulnerability_summarizer.py
+++ b/vulnerability_summarizer.py
@@ -52,6 +52,9 @@ def get_patch_list(repo):
     alert so to get down to one recommended version per package you have to do an
     aggregation for the advisories in each alert and then to see if there are
     multiple alerts for the same package.
+
+    Also the highest patched version may not correspond to the highest severity
+    of all the advisories.
     """
     repo_patches = {}
     for v_edge in repo.vulnerabilityAlerts.edges:

--- a/vulnerability_summarizer.py
+++ b/vulnerability_summarizer.py
@@ -1,3 +1,5 @@
+import re
+
 from addict import Dict
 
 SEVERITIES = ["LOW", "MODERATE", "HIGH", "CRITICAL"]
@@ -26,3 +28,98 @@ def group_by_severity(repositories):
         severity = get_max_severity(repo)
         vulnerable_by_severity[severity].append(repo)
     return vulnerable_by_severity
+
+
+def get_uniform_version(version):
+    components = re.findall(r"\d+", version)
+    uniform = ".".join(components)
+    return uniform
+
+
+def get_sortable_version(version):
+    version_components = re.findall(r"\d+", version)
+    print(version_components)
+    sortable = []
+    for component in version_components:
+        sortable.append(format(int(component), "04d"))
+
+    return ".".join(sortable)
+
+
+def get_patch_list(repo):
+    """
+    The same package can have multiple alerts or multiple advisories within the same
+    alert so to get down to one recommended version per package you have to do an
+    aggregation for the advisories in each alert and then to see if there are
+    multiple alerts for the same package.
+    """
+    repo_patches = {}
+    for v_edge in repo.vulnerabilityAlerts.edges:
+        package = v_edge.node.packageName
+        print(package)
+        dependency_file = v_edge.node.vulnerableManifestPath
+        required_version = get_uniform_version(v_edge.node.vulnerableRequirements)
+        sortable_version = get_sortable_version(required_version)
+        print(f"{required_version} == {sortable_version}")
+
+        patch_sortable_version = None
+        patch_version = None
+        patchable = False
+        max_severity = 0
+        advisories = v_edge.node.securityAdvisory.vulnerabilities.edges
+        for a_edge in advisories:
+            advisory = a_edge.node
+            severity_index = SEVERITIES.index(advisory.severity)
+            if severity_index > max_severity:
+                max_severity = severity_index
+
+            if advisory.firstPatchedVersion:
+                patchable = True
+                advisory_patch_version = get_uniform_version(
+                    advisory.firstPatchedVersion.identifier
+                )
+                advisory_sortable_version = get_sortable_version(advisory_patch_version)
+
+                if (not patch_version) or (
+                    advisory_sortable_version > patch_sortable_version
+                ):
+                    patch_version = advisory_patch_version
+                    patch_sortable_version = advisory_sortable_version
+
+        first = package not in repo_patches
+        later = False
+
+        if package in repo_patches:
+            later = patch_sortable_version and (
+                repo_patches[package]["sortable_version"] < patch_sortable_version
+            )
+            if repo_patches[package]["severity_index"] > max_severity:
+                max_severity = repo_patches[package]["severity_index"]
+
+        newer = first or later
+
+        if newer:
+            repo_patches[package] = {
+                "package": package,
+                "dependency_file": dependency_file,
+                "current_version": required_version,
+                "patch_available": patchable,
+                "patch_version": patch_version,
+                "sortable_version": patch_sortable_version,
+                "severity": SEVERITIES[max_severity],
+                "severity_index": max_severity,
+            }
+            print(
+                f"For {repo.name} patch {package} from {required_version} to {patch_version}"
+            )
+
+    # sort by descending severity
+    if len(repo_patches.keys()) > 0:
+        patch_list = [patch for package, patch in repo_patches.items()]
+        patch_list.sort(key=lambda patch: patch["severity_index"], reverse=True)
+        print(patch_list)
+        patches = {patch["package"]: patch for patch in patch_list}
+    else:
+        patches = {}
+
+    return patches


### PR DESCRIPTION
and add tests of version comparison logic.

This still needs more work. There can be both multiple advisories within the same alert suggesting different patches and multiple alerts for the same package. At the moment this is being handled by one big function. 