### PR TITLE
Rename today, refactor route and implement accordion for repos by status

### DIFF
--- a/app.py
+++ b/app.py
@@ -522,11 +522,22 @@ def route_data_overview_repositories_by_status(today):
     severities = vulnerability_summarizer.SEVERITIES
 
     template_data = {
-        "repositories": {"all": repo_count, "by_status": status_counts},
-        "updated": today,
+        "content": {
+            "title": "Overview - Repositories by status",
+            "org": config.get_value("github_org"),
+            "repositories": {
+                "all": repo_count,
+                "by_status": status_counts,
+                "repos_by_status": repositories_by_status,
+            },
+            "vulnerable_by_severity": vulnerable_by_severity,
+        },
+        "footer": {"updated": today},
     }
 
-    overview_status = storage.save_json(f"{today}/routes/overview.json", template_data)
+    overview_status = storage.save_json(
+        f"{today}/routes/overview_repositories_by_status.json", template_data
+    )
     return overview_status
 
 
@@ -564,14 +575,14 @@ def route_data_overview_vulnerable_repositories(today):
                 "by_severity": severity_counts,
                 "repositories": vulnerable_by_severity,
             },
-            "alert_status": alert_status
+            "alert_status": alert_status,
         },
-        "footer": {
-            "updated": today
-        }
+        "footer": {"updated": today},
     }
 
-    template_status = storage.save_json(f"{today}/routes/overview_vulnerable_repositories.json", template_data)
+    template_status = storage.save_json(
+        f"{today}/routes/overview_vulnerable_repositories.json", template_data
+    )
     return template_status
 
 
@@ -626,17 +637,14 @@ def route_overview():
 @app.route("/overview/repository-status")
 def route_overview_repository_status():
     try:
-        # today = datetime.date.today().isoformat()
-        today = get_current_audit()
-        content = {"title": "Overview - Repository status"}
-        footer = {"updated": today}
-        repo_stats = storage.read_json(f"{today}/routes/overview.json")
+        current = get_current_audit()
+        template_data = storage.read_json(
+            f"{current}/routes/overview_repositories_by_status.json"
+        )
         return render_template(
             "pages/overview_repository_status.html",
             header=get_header(),
-            content=content,
-            footer=footer,
-            data=repo_stats,
+            **template_data,
         )
     except FileNotFoundError as err:
         return render_template(
@@ -648,16 +656,16 @@ def route_overview_repository_status():
 def route_overview_vulnerable_repositories():
     try:
         current = get_current_audit()
-        template_data = storage.read_json(f"{current}/routes/overview_vulnerable_repositories.json")
+        template_data = storage.read_json(
+            f"{current}/routes/overview_vulnerable_repositories.json"
+        )
         return render_template(
             "pages/overview_vulnerable_repositories.html",
             header=get_header(),
-            **template_data
+            **template_data,
         )
     except FileNotFoundError as err:
-        return render_template(
-            "pages/error.html", **get_error_data("File not found.")
-        )
+        return render_template("pages/error.html", **get_error_data("File not found."))
 
 
 @app.route("/overview/repository-monitoring-status")

--- a/templates/pages/overview_repository_status.html
+++ b/templates/pages/overview_repository_status.html
@@ -17,7 +17,7 @@
          palette='["#0362fc","#fc8c03","#a587c9","#8d8696"]'
       >
         <table class="govuk-table">
-          <caption class="govuk-table__caption">Repositories by status ({{ data.repositories.all }})</caption>
+          <caption class="govuk-table__caption">Repositories by status ({{ content.repositories.all }})</caption>
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
               <th class="govuk-table__header">Status</th>
@@ -25,13 +25,13 @@
             </tr>
           </thead>
           <tbody class="govuk-table__body">
-            {% for status in data.repositories.by_status %}
+            {% for status in content.repositories.by_status %}
             <tr class="govuk-table__row">
               <th class="govuk-table__header">
                 {{ status | title }}
               </th>
               <td class="govuk-table__cell govuk-table__cell--numeric">
-                {{ data.repositories.by_status[status] }}
+                {{ content.repositories.by_status[status] }}
               </td>
             </tr>
             {% endfor %}
@@ -45,6 +45,32 @@
         For those which are neither archived or disabled they are separated
         into public or private.
       </p>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-status">
+      {% for status in content.repositories.by_status %}
+
+        <div class="govuk-accordion__section ">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-status-heading-{{status}}">
+                {{ status | title}} ({{ content.repositories.by_status[status] }})
+              </span>
+            </h2>
+          </div>
+          <div id="accordion-status-content-{{status}}" class="govuk-accordion__section-content" aria-labelledby="accordion-status-heading-{{status}}">
+
+          {% set repositories = content.repositories.repos_by_status[status] %}
+          {% for repo in repositories %}
+            {% include "components/content_blocks/repository_summary.html" %}
+          {% endfor %}
+          </div>
+        </div>
+      {% endfor %}
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/templates/pages/overview_vulnerable_repositories.html
+++ b/templates/pages/overview_vulnerable_repositories.html
@@ -83,9 +83,9 @@
             {% include "components/content_blocks/repository_summary.html" %}
           {% endfor %}
           </div>
+        </div>
       {% endfor %}
       </div>
-
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
This work edited the today var to be current as today may not be the most recent audit. The route template data was refactored to be consistent with the by vulnerabilities page and the accordion has been added at the bottom of the page with each section based on the status (e.g. public, private). Card no. 120.