### PR TITLE
update dependabot policy to add logs to cloudwatch

### DIFF
--- a/build/terraform/dependabot_lambda.tf
+++ b/build/terraform/dependabot_lambda.tf
@@ -17,7 +17,7 @@ resource "aws_lambda_function" "lambda" {
 
   environment {
     variables = {
-      GITHUB_KEY = "AQICAHhe01flQwZvqnxcRcriXcTn8QzO9B5PrggjEtFLxnGsSwGhx9NZkLHKsfr4AaF0MplCAAAAiDCBhQYJKoZIhvcNAQcGoHgwdgIBADBxBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDIWO4VVrz5kCj2FUNwIBEIBE7mON+d6P+9Jo3ogiMXHpGM/l64jU3IAqpXE2pE5Fn/Dmg2Tdavzpmlw3mDnSkdICweIW7Qc9cw2t4QjfPGcg6ttBTPM=",
+      GITHUB_TOKEN = "AQICAHhe01flQwZvqnxcRcriXcTn8QzO9B5PrggjEtFLxnGsSwGhx9NZkLHKsfr4AaF0MplCAAAAiDCBhQYJKoZIhvcNAQcGoHgwdgIBADBxBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDIWO4VVrz5kCj2FUNwIBEIBE7mON+d6P+9Jo3ogiMXHpGM/l64jU3IAqpXE2pE5Fn/Dmg2Tdavzpmlw3mDnSkdICweIW7Qc9cw2t4QjfPGcg6ttBTPM=",
       FLASK_ENV = "production"
     }
   }

--- a/build/terraform/dependabot_lambda.tf
+++ b/build/terraform/dependabot_lambda.tf
@@ -17,7 +17,6 @@ resource "aws_lambda_function" "lambda" {
 
   environment {
     variables = {
-      GITHUB_TOKEN = "AQICAHhe01flQwZvqnxcRcriXcTn8QzO9B5PrggjEtFLxnGsSwGhx9NZkLHKsfr4AaF0MplCAAAAiDCBhQYJKoZIhvcNAQcGoHgwdgIBADBxBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDIWO4VVrz5kCj2FUNwIBEIBE7mON+d6P+9Jo3ogiMXHpGM/l64jU3IAqpXE2pE5Fn/Dmg2Tdavzpmlw3mDnSkdICweIW7Qc9cw2t4QjfPGcg6ttBTPM=",
       FLASK_ENV = "production"
     }
   }

--- a/build/terraform/dependabot_lambda_iam.tf
+++ b/build/terraform/dependabot_lambda_iam.tf
@@ -2,7 +2,6 @@ data "template_file" "dependabot_lambda_policy" {
   template = "${file("${path.module}/json/dependabot_lambda/policy.json")}"
   vars = {
       region         = "${var.region}"
-      lambda_logarn  = "${var.dependabot_lambda_logarn}"
       aws_account_id = "${var.aws_account_id}"
   }
 }

--- a/build/terraform/json/dependabot_lambda/policy.json
+++ b/build/terraform/json/dependabot_lambda/policy.json
@@ -20,11 +20,12 @@
         {
             "Effect": "Allow",
             "Action": [
-              "ssm:DescribeParameters",
-              "ssm:GetParameters"
+                "ssm:GetParameter",
+                "ssm:GetParameters",
+                "ssm:GetParametersByPath"
             ],
             "Resource": [
-                "arn:aws:ssm:${region}:${aws_account_id}:key/alias/security-advisories-prod-kms"
+                "arn:aws:ssm:${region}:${aws_account_id}:parameter/ssd/github/*"
             ]
         },
         {

--- a/build/terraform/json/dependabot_lambda/policy.json
+++ b/build/terraform/json/dependabot_lambda/policy.json
@@ -4,7 +4,18 @@
         {
             "Effect": "Allow",
             "Action": "logs:CreateLogGroup",
-            "Resource": "${lambda_logarn}:*"
+            "Resource": "arn:aws:logs:${region}:${aws_account_id}:*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": [
+                "arn:aws:logs:${region}:${aws_account_id}:log-group:/aws/lambda/cyber_dependabot:*"
+            ]
         },
         {
             "Effect": "Allow",

--- a/build/terraform/variables.tf
+++ b/build/terraform/variables.tf
@@ -40,7 +40,3 @@ variable "dependabot_lambda_memory" {
 variable "dependabot_lambda_timeout" {
   default  = 900
 }
-
-variable "dependabot_lambda_logarn" {
-  default  = "arn:aws:logs:eu-west-2:*"
-}

--- a/build/terraform/variables.tf
+++ b/build/terraform/variables.tf
@@ -34,7 +34,7 @@ variable "dependabot_lambda_handler" {
 }
 
 variable "dependabot_lambda_memory" {
-  default  = 128
+  default  = 1024
 }
 
 variable "dependabot_lambda_timeout" {

--- a/cyber_dependabot.py
+++ b/cyber_dependabot.py
@@ -4,11 +4,9 @@ import logging
 from collections import Counter
 from typing import Iterator, Callable
 from concurrent.futures import ThreadPoolExecutor
-from base64 import b64decode
 
 from addict import Dict
 import requests
-import boto3
 
 
 import storage
@@ -19,13 +17,10 @@ def put(path: str) -> requests.models.Response:
     """
     Adapter of `requests.put()`, supplying github credentials.
     """
-    ENCRYPTED_GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
-    DECRYPTED_GITHUB_TOKEN = boto3.client("kms").decrypt(
-        CiphertextBlob=b64decode(ENCRYPTED_GITHUB_TOKEN)
-    )["Plaintext"]
+    GITHUB_TOKEN = config.get_value("token")
     ROOT_URL = "https://api.github.com"
     headers = {
-        "Authorization": f"token {DECRYPTED_GITHUB_TOKEN}",
+        "Authorization": f"token {GITHUB_TOKEN}",
         "Accept": "application/vnd.github.dorian-preview+json",
     }
     return requests.put(f"{ROOT_URL}{path}", headers=headers)


### PR DESCRIPTION
- this PR updates the dependabot lambda policy so that it has permissions to create and write to cloudwatch logs