### PR TITLE
Change Dependabot API endpoint to use /active_repos

### DIFF
--- a/audit_lambda.py
+++ b/audit_lambda.py
@@ -148,25 +148,15 @@ def get_github_activity_prs_audit(org, today):
 
 def get_dependabot_status(org, today):
     dependabot_status = dependabot_api.get_repos_by_status(org)
-    counts = stats.count_types(dependabot_status)
-    output = Dict()
-    output.counts = counts
-    output.repositories = dependabot_status
-
-    storage.save_json(f"{today}/data/dependabot_status.json", output)
+    storage.save_json(f"{today}/data/dependabot_status.json", dependabot_status)
 
     repositories = storage.read_json(f"{today}/data/repositories.json")
 
-    for repo in repositories["active"]:
-        repo.dependabotEnabledStatus = False
+    dependabot_repo_names = [r.attributes.name for r in dependabot_status]
+    for r in repositories["active"]:
+        r.dependabotEnabledStatus = r.name in dependabot_repo_names
 
-    for dbot_repo in dependabot_status["active"]:
-        for repo in repositories["active"]:
-            if dbot_repo.attributes.name == repo.name:
-                repo.dependabotEnabledStatus = True
-                break
-
-    updated = storage.save_json(f"{today}/data/repositories.json", repositories)
+    storage.save_json(f"{today}/data/repositories.json", repositories)
 
 
 def analyse_repo_ownership(today):

--- a/dependabot_api.py
+++ b/dependabot_api.py
@@ -1,8 +1,8 @@
 import os
 import json
+
 import requests
 from addict import Dict
-
 
 import config
 
@@ -30,7 +30,7 @@ def get_repos_by_status(org):
         if account.attributes["github-login"] == org:
             for state in states:
                 repositories[state] = get_parsed(
-                    f"/repos?account-id={account.id}&account-type=org&installation-state={state}"
+                    f"/active_repos?account-id={account.id}&account-type=org"
                 )
 
     return repositories

--- a/dependabot_api.py
+++ b/dependabot_api.py
@@ -24,13 +24,10 @@ def get_parsed(path):
 
 def get_repos_by_status(org):
     accounts = get_parsed("/accounts")
-    states = ["active", "inactive"]
-    repositories = {}
     for account in accounts:
         if account.attributes["github-login"] == org:
-            for state in states:
-                repositories[state] = get_parsed(
-                    f"/active_repos?account-id={account.id}&account-type=org"
-                )
+            repositories = get_parsed(
+                f"/active_repos?account-id={account.id}&account-type=org"
+            )
 
     return repositories


### PR DESCRIPTION
The `/repos` endpoint has been throwing a 500 for about over a
week. We have moved to an undocumented API endpoint that seems to work
for our usecase. We found the endpoint from using
https://app.dependabot.com/accounts/alphagov

I'm not sure how stable this endpoint will be, but it works for now.

Co-authored-by: Tristram Oaten <tristram@oaten.name>

