### PR TITLE
fix broken test_config test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ rebuild:
 
 test:
 	export FLASK_ENV=development
-	docker-compose run dashboard ./test.sh tests
+	docker-compose run -e TOKEN=faketoken dashboard ./test.sh tests
 
 contract-test:
 	export FLASK_ENV=development

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ to build the static assets, js and css.
 make run
 ```
 
+## Run the tests
+
+Run the unit tests by running
+
+```test
+make test
+```
+
 ## Terraform
 
 ### Build

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,8 +4,6 @@ import sys
 import config
 
 REGION = "eu-west-2"
-token_value = "123abc"
-os.environ["TOKEN"] == token_value
 
 
 def test_load():
@@ -20,10 +18,12 @@ def test_load():
 
 def test_get_value():
     """
-    Test retrieving a settings from an env variable defined above
+    Test config.get_value retrieves correct value
+    value is set to "faketoken" in env on concourse and when
+    running locally.
     """
     value = config.get_value("token")
-    assert not value == token_value, "Env var returned correctly"
+    assert value == "faketoken", "Env var returned correctly"
 
 
 def test_get_value_ssm():


### PR DESCRIPTION
Previously, this test was breaking because there was no set env "TOKEN" in the docker container where the tests were run. 

This PR fixes the broken test_config test by:
- passing a fake token of "faketoken" to the docker where tests are run locally
- asserting that the get_config token equals "faketoken"
- this also works on concourse as we pass in TOKEN=faketoken in the pipeline.yml