### PR TITLE
test_splunk flake8 error

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-03-19T16:56:10Z",
+  "generated_at": "2020-05-14T09:29:59Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -97,7 +97,7 @@
       }
     ]
   },
-  "version": "0.13.0",
+  "version": "0.13.1",
   "word_list": {
     "file": null,
     "hash": null

--- a/tests/test_splunk.py
+++ b/tests/test_splunk.py
@@ -46,7 +46,7 @@ def test_splunk_send_data_files(splunk, mocker, vuln):
             json.dumps(
                 {
                     "host": "advisory_dashboard",
-                    "source": f"vulnerable_by_severity",
+                    "source": "vulnerable_by_severity",
                     "event": v,
                 }
             ),


### PR DESCRIPTION
Resolves the following line from Flake8:
```
security-advisory-dashboard-git/tests/test_splunk.py:49:31: F541 f-string is missing placeholders
```

(Also updates the `.secrets.baseline` file, because I'm using a more up-to-date version of gds-pre-commit, which means a newer version of detect-secrets... Sorry!)