### PR TITLE
add cw permisions to correct file, relates #315

### DIFF
--- a/build/terraform/json/interface_lambda/policy.json
+++ b/build/terraform/json/interface_lambda/policy.json
@@ -9,12 +9,12 @@
         {
             "Effect": "Allow",
             "Action": [
-                "logs:CreateLogGroup",
                 "logs:CreateLogStream",
+                "logs:DescribeLogStream",
                 "logs:PutLogEvents"
             ],
             "Resource": [
-                "arn:aws:logs:${region}:${account_id}:log-group:/aws/lambda/github_audit:*"
+                "arn:aws:logs:${region}:${account_id}:log-group:/aws/lambda/github_audit_collector:*"
             ]
         },
         {


### PR DESCRIPTION
Turns out the audit lambda doesn't use the audit_lambda/policy.json...
So I've added these permissions to get cw logs working into the right place. 