### PR TITLE
Add docker hub creds to health worker

### DIFF
--- a/build/concourse/pipeline.yml
+++ b/build/concourse/pipeline.yml
@@ -70,6 +70,8 @@ resource_types:
     source:
       repository: gdscyber/http-api-resource
       tag: 1.0a
+      username: ((docker_hub_username))
+      password: ((docker_hub_password))
 
 blocks:
   - &every-weekday


### PR DESCRIPTION
I'm assuming the docker-image pulling ((ecs_repo)) is pulling
from ECR not docker hub