### PR TITLE
revert graphql-core to <v3.0.0

### DIFF
--- a/audit_lambda.py
+++ b/audit_lambda.py
@@ -309,8 +309,8 @@ def analyse_vulnerability_patch_recommendations(today):
                     log.debug(repo.name)
                     repo.maxSeverity = severity
                     repo.patches = vulnerability_summarizer.get_patch_list(repo)
-                    repo.vulnerabiltyCounts = vulnerability_summarizer.get_repository_severity_counts(
-                        repo
+                    repo.vulnerabiltyCounts = (
+                        vulnerability_summarizer.get_repository_severity_counts(repo)
                     )
 
     updated = storage.save_json(f"{today}/data/repositories.json", repositories)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ gql==2.0.0
 requests==2.25.1
 boto3==1.17.83
 arrow==1.1.0
-graphql-core<4.0.0
+graphql-core<3.0.0


### PR DESCRIPTION
`make test` now passing -:

```
============================================================ test session starts ============================================================
platform linux -- Python 3.7.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /root/.pyenv/versions/3.7.5/bin/python3.7
cachedir: .pytest_cache
Using --random-order-bucket=module
Using --random-order-seed=184936

rootdir: /usr/src/app, configfile: tox.ini
plugins: mock-3.6.1, random-order-1.0.4, cov-2.12.1, flake8-1.0.7
collecting ... SET: {'type': 'local', 'location': 'output'} <_io.TextIOWrapper name='<stderr>' mode='w' encoding='UTF-8'>
collected 40 items                                                                                                                          

tests/test_vulnerability_summarizer.py::FLAKE8 PASSED
tests/test_vulnerability_summarizer.py::test_get_uniform_version PASSED
tests/test_vulnerability_summarizer.py::test_get_sortable_version ['1', '2', '3']
['1', '12', '3']
['1', '12', '20']
['1', '2', '3']
['1', '12', '3']
PASSED
tests/test_cyber_dependabot.py::test_enable_alert_ignores_correct_tags PASSED
tests/test_cyber_dependabot.py::test_enable_alert_ignores_correct_repos PASSED
tests/test_cyber_dependabot.py::test_enable_alerts_enables_correct_repos PASSED
tests/test_cyber_dependabot.py::test_get_topics PASSED
tests/test_cyber_dependabot.py::FLAKE8 PASSED
tests/test_audit_lambda.py::FLAKE8 PASSED
tests/test_audit_lambda.py::test_send_vulnerable_by_severtiy_to_splunk [call({})]
PASSED
tests/test_app.py::FLAKE8 PASSED
tests/__init__.py::FLAKE8 PASSED
tests/test_config.py::FLAKE8 PASSED
tests/test_config.py::test_get_value PASSED
tests/test_config.py::test_load {'token': {'source': 'env', 'name': 'TOKEN'}, 'github_org': {'source': 'env', 'name': 'GITHUB_ORG'}, 'storage': {'source': 'this', 'name': {'type': 'local', 'location': 'output'}}, 'splunk_host': {'source': 'ssm', 'name': '/ssd/github/splunk_host'}, 'splunk_token': {'source': 'ssm', 'name': '/ssd/github/splunk_token'}, 'aws_region': {'source': 'this', 'name': 'eu-west-2'}} <_io.TextIOWrapper name='<stderr>' mode='w' encoding='UTF-8'>
PASSED
tests/test_config.py::test_get_value_ssm PASSED
tests/test_vulnerable_by_severity_splunk.py::test_vulnerability_alerts_vulnerability_alert_size PASSED
tests/test_vulnerable_by_severity_splunk.py::test_vulnerability_alerts_vulnerabiliteis_type PASSED
tests/test_vulnerable_by_severity_splunk.py::test_project_topics PASSED
tests/test_vulnerable_by_severity_splunk.py::test_vulnerability_alert_splunk_format PASSED
tests/test_vulnerable_by_severity_splunk.py::FLAKE8 PASSED
tests/test_vulnerable_by_severity_splunk.py::test_project_owner PASSED
tests/test_vulnerable_by_severity_splunk.py::test_project_vulnerability_alerts_size PASSED
tests/test_vulnerable_by_severity_splunk.py::test_vulnerability_first_patched_version_empty PASSED
tests/test_vulnerable_by_severity_splunk.py::test_vulnerability_iter PASSED
tests/test_vulnerable_by_severity_splunk.py::test_vulnerability_first_patched_version PASSED
tests/test_vulnerable_by_severity_splunk.py::test_vulnerability_alert_iter PASSED
tests/test_vulnerable_by_severity_splunk.py::test_project_vulnerability_alerts_type PASSED
tests/test_vulnerable_by_severity_splunk.py::test_project_iter PASSED
tests/test_vulnerable_by_severity_splunk.py::test_project_vulnerability_alerts PASSED
tests/test_vulnerable_by_severity_splunk.py::test_project_splunk_format PASSED
tests/test_storage.py::test_get_set_options SET: {'type': 'local', 'location': 'output'} <_io.TextIOWrapper name='<stderr>' mode='w' encoding='UTF-8'>
GET:{'type': 'local', 'location': 'output'} <_io.TextIOWrapper name='<stderr>' mode='w' encoding='UTF-8'>
PASSED
tests/test_storage.py::test_save_s3 SKIPPED (Breaks when run out of order)
tests/test_storage.py::test_read_s3 SKIPPED (Breaks when run out of order)
tests/test_storage.py::test_save SKIPPED (Breaks when run out of order)
tests/test_storage.py::test_read_json SKIPPED (Breaks when run out of order)
tests/test_storage.py::FLAKE8 PASSED
tests/test_splunk.py::test_splunk_send_data_files PASSED
tests/test_splunk.py::test_send_json PASSED
tests/test_splunk.py::FLAKE8 PASSED

----------- coverage: platform linux, python 3.7.5-final-0 -----------
Coverage HTML written to dir htmlcov


========================================================== short test summary info ==========================================================
SKIPPED [1] tests/test_storage.py:43: Breaks when run out of order
SKIPPED [1] tests/test_storage.py:62: Breaks when run out of order
SKIPPED [1] tests/test_storage.py:26: Breaks when run out of order
SKIPPED [1] tests/test_storage.py:33: Breaks when run out of order
======================================================= 36 passed, 4 skipped in 2.91s =======================================================
```