### PR TITLE
Remove requirement for separately build container image

### DIFF
--- a/build/concourse/pipeline.yml
+++ b/build/concourse/pipeline.yml
@@ -28,12 +28,12 @@ resources:
           pipeline: "{BUILD_PIPELINE_NAME}"
           job: "{BUILD_JOB_NAME}"
           build_number: "{BUILD_NAME}"
-        service: "GitHub Security Advisories"
+        service: "security-advisory-dashboard"
 
-  - name: sec_adv_docker
+  - name: concourse_base_image
     type: docker-image
     source:
-      repository: ((ecs_repo))
+      repository: gdscyber/cyber-security-concourse-base-image
       <<: *docker_hub_creds
 
   - name: cyber-security-infrastructure
@@ -74,8 +74,8 @@ blocks:
     get: security-advisory-dashboard-git
     trigger: true
 
-  - &sec_adv_docker
-    get: sec_adv_docker
+  - &concourse_base_image
+    get: concourse_base_image
     trigger: true
 
   - config: &audit_lambda_build
@@ -88,7 +88,7 @@ blocks:
       image_resource:
         type: docker-image
         source:
-          repository: ((ecs_repo))
+          repository: gdscyber/cyber-security-concourse-base-image
           <<: *docker_hub_creds
 
       inputs:
@@ -98,15 +98,17 @@ jobs:
   - name: sec_adv_tests
     plan:
       - *security-advisory-dashboard-git
-      - *sec_adv_docker
+      - *concourse_base_image
       - task: test
         config:
           <<: *audit_lambda_build
           run:
             path: /bin/bash
-            args:
-              - test.sh
-              - tests
+            args: |
+              pip install -r requirements-dev.context
+              pip install -r requirements.txt
+              export PYTHONDONTWRITEBYTECODE=1
+              ./test.sh tests
             dir: security-advisory-dashboard-git
           params:
             FLASK_ENV: development
@@ -126,7 +128,7 @@ jobs:
   - name: github_contract_tests
     plan:
       - *security-advisory-dashboard-git
-      - *sec_adv_docker
+      - *concourse_base_image
       - *every-weekday
       - task: contract_test
         config:
@@ -138,7 +140,10 @@ jobs:
               - |
                 source /usr/local/bin/sts-assume-role.sh 'arn:aws:iam::779799343306:role/github_contract_tests_role' 'eu-west-2'
                 export FLASK_ENV="production"
-                /bin/bash test.sh contract_tests
+                pip install -r requirements-dev.context
+                pip install -r requirements.txt
+                export PYTHONDONTWRITEBYTECODE=1
+                ./test.sh contract_tests
             dir: security-advisory-dashboard-git
         on_success:
           <<: *health_status_notify
@@ -155,14 +160,14 @@ jobs:
     # Needs to create zip and output to s3
     plan:
       - *security-advisory-dashboard-git
-      - *sec_adv_docker
+      - *concourse_base_image
       - task: pack
         config:
           <<: *audit_lambda_build
           run:
             path: /bin/bash
-            args:
-              - pack.sh
+            args: |
+              pack.sh
             dir: security-advisory-dashboard-git
         on_success:
           <<: *health_status_notify
@@ -187,7 +192,7 @@ jobs:
           - sec_adv_tests
 
       - &sec_adv_docker
-        get: sec_adv_docker
+        get: concourse_base_image
         trigger: true
         passed:
           - sec_adv_tests
@@ -215,7 +220,7 @@ jobs:
               cp cyber-security-infrastructure/service/github_audit/account/779799343306/backend.tfvars security-advisory-dashboard-git/build/terraform/backend.tf
               cat cyber-security-infrastructure/service/github_audit/account/779799343306/backend.tfvars security-advisory-dashboard-git/build/terraform/backend.tf
               cd security-advisory-dashboard-git
-              bash pack.sh
+              ./pack.sh
               cd build/terraform
               source /usr/local/bin/sts-assume-role.sh 'arn:aws:iam::779799343306:role/github-advisories-concourse-role' 'eu-west-2'
               terraform init

--- a/build/concourse/pipeline.yml
+++ b/build/concourse/pipeline.yml
@@ -107,8 +107,9 @@ jobs:
             args:
               - -c
               - |
-                pip install -r requirements-dev.txt
                 export PYTHONDONTWRITEBYTECODE=1
+                pip3 install --no-cache-dir -r requirements-dev.txt
+                pip3 install --no-cache-dir -r requirements.txt
                 ./test.sh tests
             dir: security-advisory-dashboard-git
           params:
@@ -140,9 +141,10 @@ jobs:
               - -c
               - |
                 source /usr/local/bin/sts-assume-role.sh 'arn:aws:iam::779799343306:role/github_contract_tests_role' 'eu-west-2'
-                export FLASK_ENV="production"
-                pip install -r requirements-dev.txt
                 export PYTHONDONTWRITEBYTECODE=1
+                export FLASK_ENV="production"
+                pip3 install --no-cache-dir -r requirements-dev.txt
+                pip3 install --no-cache-dir -r requirements.txt
                 ./test.sh contract_tests
             dir: security-advisory-dashboard-git
         on_success:

--- a/build/concourse/pipeline.yml
+++ b/build/concourse/pipeline.yml
@@ -107,8 +107,7 @@ jobs:
             args:
               - -c
               - |
-                pip install -r requirements-dev.context
-                pip install -r requirements.txt
+                pip install -r requirements-dev.txt
                 export PYTHONDONTWRITEBYTECODE=1
                 ./test.sh tests
             dir: security-advisory-dashboard-git
@@ -142,8 +141,7 @@ jobs:
               - |
                 source /usr/local/bin/sts-assume-role.sh 'arn:aws:iam::779799343306:role/github_contract_tests_role' 'eu-west-2'
                 export FLASK_ENV="production"
-                pip install -r requirements-dev.context
-                pip install -r requirements.txt
+                pip install -r requirements-dev.txt
                 export PYTHONDONTWRITEBYTECODE=1
                 ./test.sh contract_tests
             dir: security-advisory-dashboard-git

--- a/build/concourse/pipeline.yml
+++ b/build/concourse/pipeline.yml
@@ -104,11 +104,13 @@ jobs:
           <<: *audit_lambda_build
           run:
             path: /bin/bash
-            args: |
-              pip install -r requirements-dev.context
-              pip install -r requirements.txt
-              export PYTHONDONTWRITEBYTECODE=1
-              ./test.sh tests
+            args:
+              - -c
+              - |
+                pip install -r requirements-dev.context
+                pip install -r requirements.txt
+                export PYTHONDONTWRITEBYTECODE=1
+                ./test.sh tests
             dir: security-advisory-dashboard-git
           params:
             FLASK_ENV: development
@@ -166,8 +168,9 @@ jobs:
           <<: *audit_lambda_build
           run:
             path: /bin/bash
-            args: |
-              pack.sh
+            args:
+              - -c
+              - bash pack.sh
             dir: security-advisory-dashboard-git
         on_success:
           <<: *health_status_notify

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
--r requirements.txt
 pytest==6.2.4
 black==21.5b1
 itsdangerous==2.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 pytest==6.2.4
 black==21.5b1
 itsdangerous==2.0.1


### PR DESCRIPTION
As it stands this pipeline runs against the old version of the container while the image is being rebuilt meaning that changes to the dependencies are not applied when the tests are run.

This recently broke because we merged a dependabot advisory which got through the pipeline untested and broke production.